### PR TITLE
Filter lines with comments or empty lines. 

### DIFF
--- a/bin/bs
+++ b/bin/bs
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ -f .env ]]; then
-  eval "awk 'length { print "export " $0}' .env)"
- 
+  eval "$(grep -v '^#' .env | awk 'length { print "export " $0}')"
+
   if [[ $# -gt 0 ]]; then
     "$@"
   elif [[ -z $PS2 ]]; then

--- a/bin/bs
+++ b/bin/bs
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [[ -f .env ]]; then
-  eval "$(grep -v '^#' .env | awk 'length { print "export " $0}')"
+  eval "$(awk '/^[A-Z]/ { print "export " $0 }' .env)"
+
 
   if [[ $# -gt 0 ]]; then
     "$@"

--- a/bin/bs
+++ b/bin/bs
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ -f .env ]]; then
-  eval "$(awk '{ print "export " $0}' .env)"
-
+  eval "awk 'length { print "export " $0}' .env)"
+ 
   if [[ $# -gt 0 ]]; then
     "$@"
   elif [[ -z $PS2 ]]; then


### PR DESCRIPTION
With .env files with comments or empty lines (for reading purposes) you get a ton of (unrequested) output because bs is executing export with no parameters. 
