### PR TITLE
convert to POSIX

### DIFF
--- a/bin/bs
+++ b/bin/bs
@@ -1,14 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ -f .env ]]; then
-  eval "$(awk '/^[A-Z]/ { print "export " $0 }' .env)"
+bs_function() {
+  if [ -f '.env' ]; then
+    # export `.env`.
+    # NOTE: per design not safe, as env vars are set based on output of
+    #       arbitrary commands defined in `.env`.
+    eval "$(sed -n 's|^[ \t]*[A-Za-z_][A-Za-z0-9_]*=|export &|p' '.env')"
 
-
-  if [[ $# -gt 0 ]]; then
-    "$@"
-  elif [[ -z $PS2 ]]; then
-    $SHELL
+    if [ $# -gt 0 ]; then
+      # execute command
+      "$@"
+    elif [ -z "$PS2" ]; then
+      # drop to a subshell when not in a command nor being sourced
+      $SHELL
+    fi
+  else
+    echo 'No .env file found. Aborting.' >&2
+    return 1
   fi
-else
-  echo "No .env file found. Aborting." >&2
-fi
+}
+
+bs_function "$@"


### PR DESCRIPTION
> We'll happily take patches to make bs POSIX-compliant.

Not sure of the status of the project, but came across it in my meanderings and saw the note above in the README, so here goes.

Some notes:
1. switched from `awk` to `sed` as not really dealing with fields and records,
2. allow leading blanks in `.env` to cater to people with indentation fetish,
3. restore returning error when no `.env` file found by wrapping in a function,
4. said function name can be anything, `bs_function` chosen to be somewhat unique to avoid namespace collisions, and
5. function also allows sourcing at shell startup and using function call (or alias to function call).

any feedback welcome
